### PR TITLE
App クラスの使用を停止する

### DIFF
--- a/app/controller/hotentry_view_controller.rb
+++ b/app/controller/hotentry_view_controller.rb
@@ -148,7 +148,7 @@ class HotentryViewController < HBFav2::UITableViewController
   def dealloc
     if @connection.present?
       @connection.cancel
-      App.shared.networkActivityIndicatorVisible = false
+      # App.shared.networkActivityIndicatorVisible = false
     end    
     self.unreceive_application_switch_notification
     super

--- a/app/controller/hotentry_view_controller.rb
+++ b/app/controller/hotentry_view_controller.rb
@@ -148,7 +148,7 @@ class HotentryViewController < HBFav2::UITableViewController
   def dealloc
     if @connection.present?
       @connection.cancel
-      # App.shared.networkActivityIndicatorVisible = false
+      UIApplication.sharedApplication.networkActivityIndicatorVisible = false
     end    
     self.unreceive_application_switch_notification
     super

--- a/app/controller/readability_view_controller.rb
+++ b/app/controller/readability_view_controller.rb
@@ -82,7 +82,7 @@ class ReadabilityViewController < HBFav2::UIViewController
 
     if @connection.present?
       @connection.cancel
-      # App.shared.networkActivityIndicatorVisible = false
+      UIApplication.sharedApplication.networkActivityIndicatorVisible = false
     end
 
     if @webview.loading?
@@ -91,11 +91,11 @@ class ReadabilityViewController < HBFav2::UIViewController
   end
 
   def webViewDidStartLoad (webView)
-    # App.shared.networkActivityIndicatorVisible = true
+    UIApplication.sharedApplication.networkActivityIndicatorVisible = true
   end
 
   def webViewDidFinishLoad (webView)
-    # App.shared.networkActivityIndicatorVisible = false
+    UIApplication.sharedApplication.networkActivityIndicatorVisible = false
     @indicator.stopAnimating
 
     ## 画面遷移後に begin_fullscreen が始まってしまい、ステータスバーが消えることがある

--- a/app/controller/readability_view_controller.rb
+++ b/app/controller/readability_view_controller.rb
@@ -82,7 +82,7 @@ class ReadabilityViewController < HBFav2::UIViewController
 
     if @connection.present?
       @connection.cancel
-      App.shared.networkActivityIndicatorVisible = false
+      # App.shared.networkActivityIndicatorVisible = false
     end
 
     if @webview.loading?
@@ -91,11 +91,11 @@ class ReadabilityViewController < HBFav2::UIViewController
   end
 
   def webViewDidStartLoad (webView)
-    App.shared.networkActivityIndicatorVisible = true
+    # App.shared.networkActivityIndicatorVisible = true
   end
 
   def webViewDidFinishLoad (webView)
-    App.shared.networkActivityIndicatorVisible = false
+    # App.shared.networkActivityIndicatorVisible = false
     @indicator.stopAnimating
 
     ## 画面遷移後に begin_fullscreen が始まってしまい、ステータスバーが消えることがある

--- a/app/controller/web_view_controller.rb
+++ b/app/controller/web_view_controller.rb
@@ -226,7 +226,7 @@ class WebViewController < HBFav2::UIViewController
   # UIWebView delegate
   #
   def webViewDidStartLoad (webView)
-    App.shared.networkActivityIndicatorVisible = true
+    # App.shared.networkActivityIndicatorVisible = true
   end
 
   def webViewDidFinishLoad (webView)
@@ -235,7 +235,7 @@ class WebViewController < HBFav2::UIViewController
     if @backButton.present?
       @backButton.enabled = webView.canGoBack
     end
-    App.shared.networkActivityIndicatorVisible = false
+    # App.shared.networkActivityIndicatorVisible = false
     @indicator.stopAnimating
   end
 

--- a/app/controller/web_view_controller.rb
+++ b/app/controller/web_view_controller.rb
@@ -226,7 +226,7 @@ class WebViewController < HBFav2::UIViewController
   # UIWebView delegate
   #
   def webViewDidStartLoad (webView)
-    # App.shared.networkActivityIndicatorVisible = true
+    UIApplication.sharedApplication.networkActivityIndicatorVisible = true
   end
 
   def webViewDidFinishLoad (webView)
@@ -235,7 +235,7 @@ class WebViewController < HBFav2::UIViewController
     if @backButton.present?
       @backButton.enabled = webView.canGoBack
     end
-    # App.shared.networkActivityIndicatorVisible = false
+    UIApplication.sharedApplication.networkActivityIndicatorVisible = false
     @indicator.stopAnimating
   end
 

--- a/app/model/bookmarks_manager.rb
+++ b/app/model/bookmarks_manager.rb
@@ -49,9 +49,9 @@ class BookmarksManager
       )
     end
 
-    # App.shared.networkActivityIndicatorVisible = true
+    UIApplication.sharedApplication.networkActivityIndicatorVisible = true
     group.wait
-    # App.shared.networkActivityIndicatorVisible = false
+    UIApplication.sharedApplication.networkActivityIndicatorVisible = false
 
     Response.new(@responses)
   end

--- a/app/model/bookmarks_manager.rb
+++ b/app/model/bookmarks_manager.rb
@@ -49,9 +49,9 @@ class BookmarksManager
       )
     end
 
-    App.shared.networkActivityIndicatorVisible = true
+    # App.shared.networkActivityIndicatorVisible = true
     group.wait
-    App.shared.networkActivityIndicatorVisible = false
+    # App.shared.networkActivityIndicatorVisible = false
 
     Response.new(@responses)
   end

--- a/app/view/webview.rb
+++ b/app/view/webview.rb
@@ -2,7 +2,7 @@ module HBFav2
   class WebView < UIWebView
     def stopLoading
       super
-      # App.shared.networkActivityIndicatorVisible = false
+      UIApplication.sharedApplication.networkActivityIndicatorVisible = false
     end
 
     def dealloc

--- a/app/view/webview.rb
+++ b/app/view/webview.rb
@@ -2,7 +2,7 @@ module HBFav2
   class WebView < UIWebView
     def stopLoading
       super
-      App.shared.networkActivityIndicatorVisible = false
+      # App.shared.networkActivityIndicatorVisible = false
     end
 
     def dealloc

--- a/app/view/webview_bridge.rb
+++ b/app/view/webview_bridge.rb
@@ -46,7 +46,7 @@ module HBFav2
 
     def stopLoading
       super
-      # App.shared.networkActivityIndicatorVisible = false
+      UIApplication.sharedApplication.networkActivityIndicatorVisible = false
     end
 
     def dealloc

--- a/app/view/webview_bridge.rb
+++ b/app/view/webview_bridge.rb
@@ -46,7 +46,7 @@ module HBFav2
 
     def stopLoading
       super
-      App.shared.networkActivityIndicatorVisible = false
+      # App.shared.networkActivityIndicatorVisible = false
     end
 
     def dealloc


### PR DESCRIPTION
iOS 11 b4 デバイス上で App クラスのメソッドを使用するとクラッシュする

とりあえず、コメントアウトしただけ。
ネットワーク通信した時にインジケータが回らないので要修正