### PR TITLE
App のメソッドはフルネームスペースで呼び出す

### DIFF
--- a/app/controller/account_config_view_controller.rb
+++ b/app/controller/account_config_view_controller.rb
@@ -80,14 +80,14 @@ class AccountConfigViewController < Formotion::FormController
   def save
     data = self.form.render
     if data["hatena_id"].blank?
-      App.alert("はてなIDは必須です")
+      BW::App.alert("はてなIDは必須です")
     else
       buser = User.new({ :name => data["hatena_id"] })
       buser.fetch_status do |status|
         if status == 404
-          App.alert("指定されたユーザーが見つかりません")
+          BW::App.alert("指定されたユーザーが見つかりません")
         elsif (status == 403)
-          App.alert("非公開設定のアカウントは利用できません")
+          BW::App.alert("非公開設定のアカウントは利用できません")
         else
           user = ApplicationUser.sharedUser
           previous_id = user.hatena_id

--- a/app/controller/bookmark_view_controller.rb
+++ b/app/controller/bookmark_view_controller.rb
@@ -93,7 +93,7 @@ class BookmarkViewController < HBFav2::UIViewController
               self.bookmark = bm
               @bookmarkView.bookmark = bm
             else
-              App.alert("ブックマークが見つかりません。時間をおいて再度試行してください")
+              BW::App.alert("ブックマークが見つかりません。時間をおいて再度試行してください")
             end
           end
         end

--- a/app/controller/bookmarks_view_controller.rb
+++ b/app/controller/bookmarks_view_controller.rb
@@ -23,11 +23,11 @@ class BookmarksViewController < HBFav2::UITableViewController
 
       Dispatch::Queue.main.sync do
         if not response.ok?
-          App.alert(response.message)
+          BW::App.alert(response.message)
         elsif ApplicationUser.sharedUser.hide_nocomment_bookmarks? && @bookmarks.comments.size == 0
-          App.alert("コメントがありません")
+          BW::App.alert("コメントがありません")
         elsif @bookmarks.all.size == 0
-          App.alert("ブックマークが全てプライベートモード、もしくはコメント非表示設定のエントリーです")
+          BW::App.alert("ブックマークが全てプライベートモード、もしくはコメント非表示設定のエントリーです")
         end
 
         if ApplicationUser.sharedUser.hide_nocomment_bookmarks?

--- a/app/controller/notification_config_view_controller.rb
+++ b/app/controller/notification_config_view_controller.rb
@@ -66,7 +66,7 @@ class NotificationConfigViewController < Formotion::FormController
   def save
     data = self.form.render
     if data["webhook_key"].blank?
-      App.alert("キーは必須です")
+      BW::App.alert("キーは必須です")
     else
       user = ApplicationUser.sharedUser
       user.webhook_key = data["webhook_key"]

--- a/app/controller/readability_view_controller.rb
+++ b/app/controller/readability_view_controller.rb
@@ -47,7 +47,7 @@ class ReadabilityViewController < HBFav2::UIViewController
       if response.ok? and @webview
         @webview.loadHTMLString(html, baseURL:entry[:url].nsurl)
       else
-        App.alert("変換に失敗しました: " + response.status_code.to_s)
+        BW::App.alert("変換に失敗しました: " + response.status_code.to_s)
         if @indicator.present?
           @indicator.stopAnimating
         end

--- a/app/controller/stars_view_controller.rb
+++ b/app/controller/stars_view_controller.rb
@@ -28,7 +28,7 @@ class StarsViewController < HBFav2::UITableViewController
         end
         view.reloadData
       else
-        App.alert(response.error_message)
+        BW::App.alert(response.error_message)
       end
     end
   end

--- a/app/controller/timeline_view_controller.rb
+++ b/app/controller/timeline_view_controller.rb
@@ -83,9 +83,9 @@ class TimelineViewController < HBFav2::UITableViewController
           @footer_indicator.startAnimating
         else
           if home?
-            App.alert("表示するブックマークがありません。はてな上でお気に入りユーザーを追加してください")
+            BW::App.alert("表示するブックマークがありません。はてな上でお気に入りユーザーを追加してください")
           else
-            App.alert("表示するブックマークがありません。")
+            BW::App.alert("表示するブックマークがありません。")
           end
         end
       end

--- a/app/model/feed_manager.rb
+++ b/app/model/feed_manager.rb
@@ -51,7 +51,7 @@ class FeedManager
         else
           ## 触っててウザいので出さない
           # Dispatch::Queue.main.async {
-          #   App.alert(response.error_message)
+          #   BW::App.alert(response.error_message)
           # }
         end
         Dispatch::Queue.main.async {


### PR DESCRIPTION
ネームスペースなしで App のメソッドを呼び出すとクラッシュするため。

Related to #5 